### PR TITLE
README.md: Link to production instance console

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This repo is intended to hold documents and SOPs, containing information and processes related to the maintenance the CentOS CI Infra Openshift cluster(s).
 
 - Issue Tracker(s): https://pagure.io/centos-infra/issues
+- Production instance console: https://console-openshift-console.apps.ocp.ci.centos.org
 - Project Meeting Calendar: https://github.com/CentOS/Calendar
 - Project Meeting minutes: https://www.centos.org/minutes/
 - IRC at freenode: #centos, #centos-ci, #redhat-cpe, #centos-devel, #centos-ops


### PR DESCRIPTION
The documentation here needs a section on "basics of using CentOS CI"
that's up to date.  One of those basics is the console URL.